### PR TITLE
Update converter.py with new charset

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -23,7 +23,8 @@ def resize(image, scale):
 # Convert grayscale image to ascii text
 def gs_image_to_ascii(image, negative=False):
     # Set of ascii characters
-    charset = " .,:;irsXA253hMHGS#9b&@"
+    # charset = " .,:;irsXA253hMHGS#9b&@"
+    charset = " :!?PG@"
     result = ""
 
     # Normalizing image from range(0, 255) to (0, max index of charset)


### PR DESCRIPTION
Updated the converter.py charset to a smaller but more efficient one.

While the original, large character set was accurate in representing a much larger range of detail, but most of that accuracy was lost since the average font size is too large to represent such great detail. 

With this character set, the aim was to keep a small range so the viewers focus was shifted to the image, not the characters used to make it up. Most characters are symmetrical (use of ':' instead of '.', etc.) and there is a clear visible distinction with the amount of space (which translates to grey-scale intensity) taken up by each consecutive character in the set.

As an example, here's a picture of Steve with the original charset (width set to 140): 
 
![2018-09-17 18_49_28-greenshot](https://user-images.githubusercontent.com/29309951/46248709-c73c7280-c42d-11e8-8d42-1870695ef174.png)

And a Picture of him with the updated charset: 

![2018-09-17 18_50_31-greenshot](https://user-images.githubusercontent.com/29309951/46248718-e509d780-c42d-11e8-9d4d-71a66c6fe86c.png)
